### PR TITLE
Begin Rust port with config loader

### DIFF
--- a/rust-node/Cargo.toml
+++ b/rust-node/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust-node"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+clap = { version = "4.5", features = ["derive"] }

--- a/rust-node/src/lib.rs
+++ b/rust-node/src/lib.rs
@@ -1,0 +1,55 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ProofConfig {
+    pub provingkey: String,
+    pub verifyingkey: String,
+    pub r1cs: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EthereumConfig {
+    pub source_address: String,
+    pub target_address: String,
+    pub private_key: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Config {
+    #[serde(default)]
+    pub index: u64,
+    #[serde(default)]
+    pub registered: bool,
+    pub bind_address: String,
+    pub private_key: String,
+    pub contract_address: String,
+    pub ethereum: EthereumConfig,
+    pub zkp: ProofConfig,
+}
+
+pub struct Node {
+    pub config: Config,
+}
+
+impl Node {
+    pub fn new(config: Config) -> Self {
+        Self { config }
+    }
+
+    pub fn run(&self) {
+        println!("Node running on {}", self.config.bind_address);
+    }
+
+    pub fn stop(&self) {
+        println!("Node stopped");
+    }
+}
+
+pub fn load_config(path: &str) -> Result<Config, Box<dyn std::error::Error>> {
+    let data = std::fs::read_to_string(path)?;
+    let config = serde_json::from_str(&data)?;
+    Ok(config)
+}

--- a/rust-node/src/main.rs
+++ b/rust-node/src/main.rs
@@ -1,0 +1,18 @@
+use clap::Parser;
+use rust_node::{load_config, Node};
+
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Args {
+    #[arg(short = 'c', long = "config", default_value = "./configs/config.example.json")]
+    config: String,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let config = load_config(&args.config)?;
+    let node = Node::new(config);
+    node.run();
+    // In a real implementation we would block on signal handling
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- start Rust crate `rust-node`
- implement config structs and loader
- implement minimal `Node` skeleton in Rust
- parse command-line `-c` flag for config file

## Testing
- `cargo build` *(fails: Could not connect to server)*