### PR TITLE
Continue port to Rust

### DIFF
--- a/rust-node/Cargo.toml
+++ b/rust-node/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.5", features = ["derive"] }
+num-bigint = "0.4"
+num-traits = "0.2"
+sha2 = "0.10"

--- a/rust-node/src/account.rs
+++ b/rust-node/src/account.rs
@@ -1,0 +1,37 @@
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+
+use crate::util::pad_or_trim;
+
+const ACCOUNT_SIZE: usize = 128;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Account {
+    pub index: BigUint,
+    pub public_key: (BigUint, BigUint),
+    pub balance: BigUint,
+}
+
+impl Account {
+    pub fn serialize(&self) -> [u8; ACCOUNT_SIZE] {
+        let mut buf = [0u8; ACCOUNT_SIZE];
+        let index_bytes = self.index.to_bytes_be();
+        buf[0..32].copy_from_slice(&pad_or_trim(&index_bytes, 32));
+        let pkx = self.public_key.0.to_bytes_be();
+        buf[32..64].copy_from_slice(&pad_or_trim(&pkx, 32));
+        let pky = self.public_key.1.to_bytes_be();
+        buf[64..96].copy_from_slice(&pad_or_trim(&pky, 32));
+        let bal = self.balance.to_bytes_be();
+        buf[96..128].copy_from_slice(&pad_or_trim(&bal, 32));
+        buf
+    }
+
+    pub fn deserialize(bytes: &[u8]) -> Self {
+        assert!(bytes.len() >= ACCOUNT_SIZE);
+        let index = BigUint::from_bytes_be(&bytes[0..32]);
+        let pkx = BigUint::from_bytes_be(&bytes[32..64]);
+        let pky = BigUint::from_bytes_be(&bytes[64..96]);
+        let balance = BigUint::from_bytes_be(&bytes[96..128]);
+        Account { index, public_key: (pkx, pky), balance }
+    }
+}

--- a/rust-node/src/lib.rs
+++ b/rust-node/src/lib.rs
@@ -1,5 +1,9 @@
 use serde::Deserialize;
 
+pub mod util;
+pub mod account;
+pub mod vote;
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ProofConfig {

--- a/rust-node/src/util.rs
+++ b/rust-node/src/util.rs
@@ -1,0 +1,12 @@
+pub fn pad_or_trim(bytes: &[u8], size: usize) -> Vec<u8> {
+    let len = bytes.len();
+    if len == size {
+        return bytes.to_vec();
+    }
+    if len > size {
+        return bytes[len - size..].to_vec();
+    }
+    let mut out = vec![0u8; size];
+    out[size - len..].copy_from_slice(bytes);
+    out
+}

--- a/rust-node/src/vote.rs
+++ b/rust-node/src/vote.rs
@@ -1,0 +1,25 @@
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+
+use crate::util::pad_or_trim;
+
+const VOTE_SIZE: usize = 96;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Vote {
+    pub index: u64,
+    pub request: BigUint,
+    pub block_hash: [u8; 32],
+}
+
+impl Vote {
+    pub fn serialize(&self) -> [u8; VOTE_SIZE] {
+        let mut buf = [0u8; VOTE_SIZE];
+        let index_bytes = BigUint::from(self.index).to_bytes_be();
+        buf[0..32].copy_from_slice(&pad_or_trim(&index_bytes, 32));
+        let req_bytes = self.request.to_bytes_be();
+        buf[32..64].copy_from_slice(&pad_or_trim(&req_bytes, 32));
+        buf[64..96].copy_from_slice(&self.block_hash);
+        buf
+    }
+}


### PR DESCRIPTION
## Summary
- expand the Rust implementation with account and vote modules
- add utility helper for byte padding
- expose new modules in `lib.rs`
- add bigint and hashing crates to Cargo manifest

## Testing
- `cargo check --manifest-path rust-node/Cargo.toml` *(fails: Could not connect to server)*